### PR TITLE
fix tick and add more test

### DIFF
--- a/packages/contracts/.env.template
+++ b/packages/contracts/.env.template
@@ -6,3 +6,7 @@
 #
 # Anvil default private key:
 PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+WORLD_ADDR=
+USER_ADDR=
+ROOM_ID=
+GAME_ID=

--- a/packages/contracts/src/library/Utils.sol
+++ b/packages/contracts/src/library/Utils.sol
@@ -90,41 +90,6 @@ library Utils {
     Hero.deleteRecord(heroId);
   }
 
-  // function createPieces(address _player, bool _atHome) internal returns (bytes32[] memory ids) {
-  //   bytes32[] memory heroIds = Player.getHeroes(_player);
-  //   uint256 num = heroIds.length;
-  //   ids = new bytes32[](num);
-  //   for (uint256 i; i < num; ++i) {
-  //     bytes32 heroId = heroIds[i];
-  //     bytes32 pieceId = _atHome ? heroId : getUniqueEntity();
-  //     HeroData memory hero = Hero.get(heroId);
-  //     CreatureData memory data = Creature.get(hero.creatureId);
-  //     uint8 tier = hero.tier;
-  //     uint32 health = tier > 0
-  //       ? (data.health * CreatureConfig.getItemHealthAmplifier(tier - 1)) / 100
-  //       : data.health;
-  //     Piece.set(
-  //       pieceId,
-  //       _atHome ? uint8(hero.x) : uint8(GameConfig.getLength() * 2 - 1 - hero.x),
-  //       uint8(hero.y),
-  //       tier,
-  //       health,
-  //       tier > 0 
-  //         ? (data.attack * CreatureConfig.getItemAttackAmplifier(tier - 1)) / 100 
-  //         : data.attack,
-  //       uint8(data.range),
-  //       tier > 0 
-  //         ? (data.defense * CreatureConfig.getItemDefenseAmplifier(tier - 1)) / 100 
-  //         : data.defense,
-  //       data.speed,
-  //       uint8(data.movement),
-  //       health,
-  //       hero.creatureId
-  //     );
-  //     ids[i] = pieceId;
-  //   }
-  // }
-
   function updatePlayerStreakCount(address _player, uint256 _winner) internal {
     int256 streakCount = Player.getStreakCount(_player);
     if (_winner == 1) {

--- a/packages/contracts/src/systems/MergeSystem.sol
+++ b/packages/contracts/src/systems/MergeSystem.sol
@@ -19,7 +19,7 @@ contract MergeSystem is System {
     uint256[2] memory indexes;
     bool[2] memory onBoard;
     uint256 num;
-    // search priority: hero on board hight than hero in inventory
+    // search priority: hero on board higher than hero in inventory
     uint256 length = Player.lengthHeroes(_player);
     for (uint256 i; i < length; ++i) {
       bytes32 heroId = Player.getItemHeroes(_player, i);

--- a/packages/contracts/src/systems/PieceDecisionMakeSystem.sol
+++ b/packages/contracts/src/systems/PieceDecisionMakeSystem.sol
@@ -161,7 +161,7 @@ contract PieceDecisionMakeSystem is System {
     bytes32[] memory ids1 = Board.getPieces(_player);
     bytes32[] memory ids2 = Board.getEnemyPieces(_player);
     uint256 num1 = ids1.length;
-    uint256 num2 = ids1.length;
+    uint256 num2 = ids2.length;
     uint256 length = num1 + num2;
     pieces = new RTPiece[](length);
     for (uint256 i; i < length; ++i) {

--- a/packages/contracts/test/ForkTest.t.sol
+++ b/packages/contracts/test/ForkTest.t.sol
@@ -3,13 +3,14 @@ pragma solidity >=0.8.0;
 
 import "forge-std/Test.sol";
 import { IWorld } from "../src/codegen/world/IWorld.sol";
-import { Creature, CreatureData, CreatureConfig, GameConfig, Player, ShopConfig } from "../src/codegen/Tables.sol";
+import { Creature, CreatureData, CreatureConfig, GameConfig, ShopConfig } from "../src/codegen/Tables.sol";
 import { GameRecord, Game, GameData } from "../src/codegen/Tables.sol";
+import { Player, PlayerData } from "../src/codegen/Tables.sol";
 import { Hero, HeroData } from "../src/codegen/Tables.sol";
 import { Piece, PieceData } from "../src/codegen/Tables.sol";
 import { Board, BoardData } from "../src/codegen/Tables.sol";
 
-contract StartGameTest is Test {
+contract ForkTest is Test {
     IWorld world;
     address user;
 
@@ -18,28 +19,44 @@ contract StartGameTest is Test {
         user = vm.envAddress("USER_ADDR");
     }
 
-    function testStartGame() public {
-        bytes32 roomId = bytes32(vm.envUint("ROOM_ID"));
-        vm.startPrank(user);
-        world.startGame(roomId);
-        vm.stopPrank();
-    }
+    /**
+     * @notice usage: forge test --match-test "testStartGame*" --fork-url <rpc-url> -vvv
+     */
+    // function testStartGame() public {
+    //     bytes32 roomId = bytes32(vm.envUint("ROOM_ID"));
+    //     vm.startPrank(user);
+    //     world.startGame(roomId);
+    //     vm.stopPrank();
+    // }
 
-    function testTick() public {
-        uint32 gameId = uint32(vm.envUint("GAME_ID"));
-        BoardData memory board = Board.get(world, user);
-        console.log("board status %d, turn %d", uint8(board.status), board.turn);
-        console.log("ally num %d, enemy num %d", board.pieces.length, board.enemyPieces.length);
-        for (uint256 i; i < board.pieces.length; ++i) {
-            PieceData memory piece = Piece.get(world, board.pieces[i]);
-            console.log("piece id %d, (%d,%d)", uint256(board.pieces[i]), piece.x, piece.y);
-            console.log("creature %d, health %d", piece.creatureId, piece.health);
-        }
-        for (uint256 i; i < board.pieces.length; ++i) {
-            PieceData memory piece = Piece.get(world, board.enemyPieces[i]);
-            console.log("enemy piece id %d, (%d,%d)", uint256(board.enemyPieces[i]), piece.x, piece.y);
-            console.log("creature %d, health %d", piece.creatureId, piece.health);
-        }
-        world.tick(gameId, user);
-    }
+    /**
+     * @notice usage: forge test --match-test "testTick*" --fork-url <rpc-url> -vvv
+     */
+    // function testTick() public {
+    //     uint32 gameId = uint32(vm.envUint("GAME_ID"));
+    //     PlayerData memory player = Player.get(world, user);
+    //     for (uint256 i; i < player.heroes.length; ++i) {
+    //         HeroData memory hero = Hero.get(world, player.heroes[i]);
+    //         console.log("hero id %d, (%d,%d)", uint256(player.heroes[i]), hero.x, hero.y);
+    //         console.log("creature %d, tier %d", hero.creatureId, hero.tier);
+    //     }
+    //     for (uint256 i; i < player.inventory.length; ++i) {
+    //         (uint32 creatureId, uint32 tier) = world.decodeHero(player.inventory[i]);
+    //         console.log("inventory index %d, creature %d, tier %d", i, creatureId, tier);
+    //     }
+    //     BoardData memory board = Board.get(world, user);
+    //     console.log("board status %d, turn %d", uint8(board.status), board.turn);
+    //     console.log("ally num %d, enemy num %d", board.pieces.length, board.enemyPieces.length);
+    //     for (uint256 i; i < board.pieces.length; ++i) {
+    //         PieceData memory piece = Piece.get(world, board.pieces[i]);
+    //         console.log("piece id %d, (%d,%d)", uint256(board.pieces[i]), piece.x, piece.y);
+    //         console.log("creature %d, tier %d, health %d", piece.creatureId, piece.tier, piece.health);
+    //     }
+    //     for (uint256 i; i < board.pieces.length; ++i) {
+    //         PieceData memory piece = Piece.get(world, board.enemyPieces[i]);
+    //         console.log("enemy piece id %d, (%d,%d)", uint256(board.enemyPieces[i]), piece.x, piece.y);
+    //         console.log("creature %d, health %d", piece.creatureId, piece.tier, piece.health);
+    //     }
+    //     world.tick(gameId, user);
+    // }
 }

--- a/packages/contracts/test/MatchingTest.t.sol
+++ b/packages/contracts/test/MatchingTest.t.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.0;
+
+import "forge-std/Test.sol";
+import { MudV2Test } from "@latticexyz/std-contracts/src/test/MudV2Test.t.sol";
+import { Creature, CreatureData, CreatureConfig, GameConfig, Board, Player, ShopConfig } from "../src/codegen/Tables.sol";
+import { GameRecord, Game, GameData } from "../src/codegen/Tables.sol";
+import { Hero, HeroData } from "../src/codegen/Tables.sol";
+import { Piece, PieceData } from "../src/codegen/Tables.sol";
+import { IWorld } from "../src/codegen/world/IWorld.sol";
+import { GameStatus } from "../src/codegen/Types.sol";
+
+contract MatchingTest is MudV2Test {
+    IWorld public world;
+
+    function setUp() public override {
+        super.setUp();
+        world = IWorld(worldAddress);
+
+        vm.startPrank(address(1));
+        world.createRoom(bytes32("12345"), 3, bytes32(0));
+        vm.stopPrank();
+
+        vm.startPrank(address(2));
+        world.joinRoom(bytes32("12345"));
+        vm.stopPrank();
+
+        vm.startPrank(address(3));
+        world.joinRoom(bytes32("12345"));
+        vm.stopPrank();
+
+        vm.startPrank(address(1));
+        world.startGame(bytes32("12345"));
+        vm.stopPrank();
+        vm.roll(100);
+    }
+
+    function testMultiplayer() public {
+        vm.startPrank(address(1));
+        world.surrender();
+        vm.stopPrank();
+
+        vm.startPrank(address(2));
+        world.surrender();
+        // init piece
+        world.tick(0, address(3));
+        // finish battle
+        world.tick(0, address(3));
+        assertEq(GameRecord.getItem(world, 0, 2), address(3));
+        world.createRoom(bytes32("12345"), 3, bytes32(0));
+        vm.stopPrank();
+
+        vm.startPrank(address(1));
+        world.joinRoom(bytes32("12345"));
+        vm.stopPrank();
+
+        vm.startPrank(address(2));
+        world.startGame(bytes32("12345"));
+        vm.stopPrank();
+
+        // check game
+        GameData memory game = Game.get(world, 1);
+        assertEq(uint(game.status), uint(GameStatus.PREPARING));
+
+        // check player coin and exp
+        assertEq(Player.getCoin(world, address(1)), 2);
+        assertEq(Player.getExp(world, address(1)), 1);
+    }
+
+    function testSelectOpponent() public {
+        _initPiece();
+        _printEnemy();
+        world.tick(0, address(2));
+        world.tick(0, address(1));
+        world.tick(0, address(3));
+        vm.roll(200);
+        _initPiece();
+        _printEnemy();
+    }
+
+    function _initPiece() private {
+        for (uint256 i=1; i < 4; ++i) {
+            world.tick(0, address(uint160(i)));
+        }
+    }
+
+    function _printEnemy() private {
+        address[] memory players = Game.getPlayers(world, 0);
+        console.log("players [%d, %d, %d]", uint160(players[0]), uint160(players[1]), uint160(players[2]));
+        for (uint256 i=1; i < 4; ++i) {
+            console.log("enemy of %d is %d", i, uint160(Board.getEnemy(world, address(uint160(i)))));
+        }
+    }
+}

--- a/packages/contracts/test/ReadWriteStateTest.t.sol
+++ b/packages/contracts/test/ReadWriteStateTest.t.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.0;
+
+import "forge-std/Test.sol";
+import { MudV2Test } from "@latticexyz/std-contracts/src/test/MudV2Test.t.sol";
+import { Creature, CreatureData, CreatureConfig, GameConfig, Player, ShopConfig } from "../src/codegen/Tables.sol";
+import { GameRecord, Game, GameData } from "../src/codegen/Tables.sol";
+import { Hero, HeroData } from "../src/codegen/Tables.sol";
+import { Piece, PieceData } from "../src/codegen/Tables.sol";
+import { IWorld } from "../src/codegen/world/IWorld.sol";
+import { GameStatus } from "../src/codegen/Types.sol";
+
+contract ReadWriteStateTest is MudV2Test {
+    IWorld public world;
+
+    function setUp() public override {
+        super.setUp();
+        world = IWorld(worldAddress);
+
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        // Start broadcasting transactions from the deployer account
+        vm.startBroadcast(deployerPrivateKey);
+    }
+
+    function testWriteState() public {
+        for (uint256 i; i < 10; ++i) {
+            Piece.setHealth(world, bytes32(uint256(1)), 100);
+        }
+    }
+
+    function testReadState1() public {
+        for (uint256 i; i < 10; ++i) {
+            uint32 health = Piece.getHealth(world, bytes32(uint256(1)));
+        }
+    }
+
+    function testReadState2() public {
+        for (uint256 i; i < 10; ++i) {
+            uint32 tier = Hero.getTier(world, bytes32(uint256(1)));
+            uint32 health = tier > 0
+                ? (Creature.getHealth(world, Hero.getCreatureId(world, bytes32(uint256(1)))) * CreatureConfig.getItemHealthAmplifier(world, tier - 1)) / 100
+                : Creature.getHealth(world, Hero.getCreatureId(world, bytes32(uint256(1))));
+        }
+    }
+
+    function testReadState3() public {
+        Piece.getHealth(world, bytes32(uint256(1)));
+        // Piece.getX(world, bytes32(uint256(1)));
+        // Piece.getY(world, bytes32(uint256(1)));
+    }
+
+    function testReadState4() public {
+        Piece.get(world, bytes32(uint256(1)));
+    }
+}


### PR DESCRIPTION
- fix an evm revert during tick
- let the first tick of each player to be initializing pieces without piece battling
- try to fix the bug of merging found in test on July 29. But it turns out that the merging works fine in local test env. Need more bug reports about merging.
- try to fix the bug of opponent matching found in test on July 29. It's not actually a bug. The scenario described was happened when some player finished battling on his board while some other player has not even started. Technically speaking, when a player finished battling, we swap him with the last player in list. Its purpose is realizing order shuffling after each round because it's difficult to predict the order in which boards finished . So when all the players start ticking at the same time, it would be ok.  