### PR TITLE
fix: buy hero index

### DIFF
--- a/packages/contracts/mud.config.ts
+++ b/packages/contracts/mud.config.ts
@@ -148,7 +148,6 @@ export default mudConfig({
         heroes: "bytes32[]",
         heroAltar: "uint64[]", // list heros that user can buy, creature id + tier
         inventory: "uint64[]",
-        heroAltarEmptyIds: "uint8[]",
         inventoryEmptyIds: "uint8[]",
       },
     },

--- a/packages/contracts/mud.config.ts
+++ b/packages/contracts/mud.config.ts
@@ -148,6 +148,8 @@ export default mudConfig({
         heroes: "bytes32[]",
         heroAltar: "uint64[]", // list heros that user can buy, creature id + tier
         inventory: "uint64[]",
+        heroAltarEmptyIds: "uint8[]",
+        inventoryEmptyIds: "uint8[]",
       },
     },
     CreatureConfig: {
@@ -207,7 +209,7 @@ export default mudConfig({
     WaitingRoomPassword: {
       schema: {
         passwordHash: "bytes32",
-      }
+      },
     },
     GameRecord: {
       keySchema: {
@@ -215,7 +217,7 @@ export default mudConfig({
       },
       schema: {
         players: "address[]",
-      }
+      },
     },
     Game: {
       keySchema: {
@@ -246,9 +248,9 @@ export default mudConfig({
     ZkVerifier: {
       keySchema: {},
       schema: {
-        password: "address"
-      }
-    }
+        password: "address",
+      },
+    },
   },
   modules: [
     {

--- a/packages/contracts/script/ConfigInitializer.sol
+++ b/packages/contracts/script/ConfigInitializer.sol
@@ -38,7 +38,7 @@ library ConfigInitializer {
     tierPrice[2] = 9;
 
     uint8[] memory tierRate = new uint8[](3);
-    tierRate[0] = 80;
+    tierRate[0] = 100;
     tierRate[1] = 100;
     tierRate[2] = 100;
 

--- a/packages/contracts/script/CreatureInitializer.sol
+++ b/packages/contracts/script/CreatureInitializer.sol
@@ -6,103 +6,103 @@ import { IWorld } from "../src/codegen/world/IWorld.sol";
 import { Creature, GameConfig } from "../src/codegen/Tables.sol";
 
 library CreatureInitializer {
-    function init(IWorld _world) internal {
-        // JUGGERNAUT
-        Creature.set(
-            _world,
-            0,  // index
-            650, // health
-            60,  // attack
-            1,  // range
-            5,  // defense
-            202,  // speed
-            2,  // movement
-            "https://www.dota2.com/hero/juggernaut"// uri
-        );
-        // BREWMASTER
-        Creature.set(
-            _world,
-            1,  // index
-            520, // health
-            60,  // attack
-            1,  // range
-            0,  // defense
-            102,  // speed
-            16,  // movement
-            "https://www.dota2.com/hero/brewmaster"// uri
-        );
-        // OMNIKNIGHT
-        Creature.set(
-            _world,
-            2,  // index
-            650, // health
-            60,  // attack
-            1,  // range
-            5,  // defense
-            204,  // speed
-            2,  // movement
-            "https://www.dota2.com/hero/omniknight"// uri
-        );
-        // CRYSTAL MAIDEN
-        Creature.set(
-            _world,
-            3,  // index
-            650, // health
-            65,  // attack
-            4,  // range
-            0,  // defense
-            305,  // speed
-            1,  // movement
-            "https://www.dota2.com/hero/crystalmaiden"// uri
-        );
-        // RIKI
-        Creature.set(
-            _world,
-            4,  // index
-            520, // health
-            60,  // attack
-            1,  // range
-            0,  // defense
-            104,  // speed
-            16,  // movement
-            "https://www.dota2.com/hero/riki"// uri
-        );
-        // RUBICK
-        Creature.set(
-            _world,
-            5,  // index
-            650, // health
-            65,  // attack
-            3,  // range
-            0,  // defense
-            307,  // speed
-            1,  // movement
-            "https://www.dota2.com/hero/rubick"// uri
-        );
-        // ZEUS
-        Creature.set(
-            _world,
-            6,  // index
-            650, // health
-            60,  // attack
-            1,  // range
-            5,  // defense
-            206,  // speed
-            2,  // movement
-            "https://www.dota2.com/hero/zeus"// uri
-        );
-        // HUSKAR
-        Creature.set(
-            _world,
-            7,  // index
-            650, // health
-            60,  // attack
-            1,  // range
-            5,  // defense
-            208,  // speed
-            2,  // movement
-            "https://www.dota2.com/hero/huskar"// uri
-        );
-
-    }
+  function init(IWorld _world) internal {
+    // creature id start from 1
+    // BREWMASTER
+    Creature.set(
+      _world,
+      1, // index
+      520, // health
+      60, // attack
+      1, // range
+      0, // defense
+      102, // speed
+      16, // movement
+      "https://www.dota2.com/hero/brewmaster" // uri
+    );
+    // OMNIKNIGHT
+    Creature.set(
+      _world,
+      2, // index
+      650, // health
+      60, // attack
+      1, // range
+      5, // defense
+      204, // speed
+      2, // movement
+      "https://www.dota2.com/hero/omniknight" // uri
+    );
+    // CRYSTAL MAIDEN
+    Creature.set(
+      _world,
+      3, // index
+      650, // health
+      65, // attack
+      4, // range
+      0, // defense
+      305, // speed
+      1, // movement
+      "https://www.dota2.com/hero/crystalmaiden" // uri
+    );
+    // RIKI
+    Creature.set(
+      _world,
+      4, // index
+      520, // health
+      60, // attack
+      1, // range
+      0, // defense
+      104, // speed
+      16, // movement
+      "https://www.dota2.com/hero/riki" // uri
+    );
+    // RUBICK
+    Creature.set(
+      _world,
+      5, // index
+      650, // health
+      65, // attack
+      3, // range
+      0, // defense
+      307, // speed
+      1, // movement
+      "https://www.dota2.com/hero/rubick" // uri
+    );
+    // ZEUS
+    Creature.set(
+      _world,
+      6, // index
+      650, // health
+      60, // attack
+      1, // range
+      5, // defense
+      206, // speed
+      2, // movement
+      "https://www.dota2.com/hero/zeus" // uri
+    );
+    // HUSKAR
+    Creature.set(
+      _world,
+      7, // index
+      650, // health
+      60, // attack
+      1, // range
+      5, // defense
+      208, // speed
+      2, // movement
+      "https://www.dota2.com/hero/huskar" // uri
+    );
+    // JUGGERNAUT
+    Creature.set(
+      _world,
+      8, // index
+      650, // health
+      60, // attack
+      1, // range
+      5, // defense
+      202, // speed
+      2, // movement
+      "https://www.dota2.com/hero/juggernaut" // uri
+    );
+  }
 }

--- a/packages/contracts/src/library/Utils.sol
+++ b/packages/contracts/src/library/Utils.sol
@@ -42,14 +42,10 @@ library Utils {
   function popInventoryByIndex(address _player, uint256 _index) internal returns (uint64 hero) {
     uint256 length = Player.lengthInventory(_player);
     if (length > _index) {
-      uint64 lastHero = Player.getItemInventory(_player, length - 1);
-      if ((length - 1) == _index) {
-        hero = lastHero;
-      } else {
-        hero = Player.getItemInventory(_player, _index);
-        Player.updateInventory(_player, _index, lastHero);
-      }
-      Player.popInventory(_player);
+      hero = Player.getItemInventory(_player, _index);
+
+      Player.updateInventory(_player, _index, uint64(0));
+      Player.pushInventoryEmptyIds(_player, uint8(_index));
     } else {
       revert("inv, out of index");
     }

--- a/packages/contracts/src/library/Utils.sol
+++ b/packages/contracts/src/library/Utils.sol
@@ -44,7 +44,9 @@ library Utils {
     if (length > _index) {
       hero = Player.getItemInventory(_player, _index);
 
+      // set the index as 0
       Player.updateInventory(_player, _index, uint64(0));
+      // add the index to empty Ids array
       Player.pushInventoryEmptyIds(_player, uint8(_index));
     } else {
       revert("inv, out of index");

--- a/packages/contracts/src/library/Utils.sol
+++ b/packages/contracts/src/library/Utils.sol
@@ -55,21 +55,21 @@ library Utils {
     }
   }
 
-  function popHeroAltarByIndex(address _player, uint256 _index) internal returns (uint64 hero) {
-    uint256 length = Player.lengthHeroAltar(_player);
-    if (length > _index) {
-      uint64 lastHero = Player.getItemHeroAltar(_player, length - 1);
-      if ((length - 1) == _index) {
-        hero = lastHero;
-      } else {
-        hero = Player.getItemHeroAltar(_player, _index);
-        Player.updateHeroAltar(_player, _index, lastHero);
-      }
-      Player.popHeroAltar(_player);
-    } else {
-      revert("altar, out of index");
-    }
-  }
+  // function popHeroAltarByIndex(address _player, uint256 _index) internal returns (uint64 hero) {
+  //   uint256 length = Player.lengthHeroAltar(_player);
+  //   if (length > _index) {
+  //     uint64 lastHero = Player.getItemHeroAltar(_player, length - 1);
+  //     if ((length - 1) == _index) {
+  //       hero = lastHero;
+  //     } else {
+  //       hero = Player.getItemHeroAltar(_player, _index);
+  //       Player.updateHeroAltar(_player, _index, lastHero);
+  //     }
+  //     Player.popHeroAltar(_player);
+  //   } else {
+  //     revert("altar, out of index");
+  //   }
+  // }
 
   function deleteHeroByIndex(address _player, uint256 _index) internal returns (HeroData memory hero) {
     uint256 length = Player.lengthHeroes(_player);
@@ -115,7 +115,11 @@ library Utils {
     }
   }
 
-  function settleBoard(uint32 _gameId, address _player, uint256 _playerHealth) internal returns (bool roundEnded, bool gameFinished) {
+  function settleBoard(
+    uint32 _gameId,
+    address _player,
+    uint256 _playerHealth
+  ) internal returns (bool roundEnded, bool gameFinished) {
     (int256 index, address[] memory players) = getIndexOfLivingPlayers(_gameId, _player);
     popGamePlayerByIndex(_gameId, uint256(index));
 
@@ -139,7 +143,7 @@ library Utils {
         // just return, no need to set finished board because game would be deleted entirely
         return (roundEnded, gameFinished);
       }
-    } 
+    }
     Game.setFinishedBoard(_gameId, uint8(finishedBoard));
   }
 
@@ -177,7 +181,10 @@ library Utils {
     Board.setEnemyPieces(_player, new bytes32[](0));
   }
 
-  function getIndexOfLivingPlayers(uint32 _gameId, address _player) internal returns (int256 index, address[] memory players) {
+  function getIndexOfLivingPlayers(
+    uint32 _gameId,
+    address _player
+  ) internal returns (int256 index, address[] memory players) {
     players = Game.getPlayers(_gameId);
     uint256 num = players.length;
     for (uint256 i; i < num; ++i) {

--- a/packages/contracts/src/systems/MergeSystem.sol
+++ b/packages/contracts/src/systems/MergeSystem.sol
@@ -55,11 +55,7 @@ contract MergeSystem is System {
    * @param _indexes an array of indexes of player's hero on board or in inventory that he wants to merge
    * @param _onBoard an array of bool which indicates whether the corresponding index is based on Player.heroes
    */
-  function mergeHero(
-    address _player,
-    uint256[2] memory _indexes,
-    bool[2] memory _onBoard
-  ) private {
+  function mergeHero(address _player, uint256[2] memory _indexes, bool[2] memory _onBoard) private {
     // delete hero on board and hero in inventory
     // start from the last index to the first index.
     // Because the indexes are put into array from lower to higher, then

--- a/packages/contracts/src/systems/PlaceSystem.sol
+++ b/packages/contracts/src/systems/PlaceSystem.sol
@@ -106,7 +106,7 @@ contract PlaceSystem is System {
     uint64 toHero = Player.getItemInventory(player, toIndex);
 
     // set both
-    Player.updateInventory(player, fromHero, toHero);
+    Player.updateInventory(player, fromIndex, toHero);
     Player.updateInventory(player, toIndex, fromHero);
   }
 

--- a/packages/contracts/src/systems/RefreshHeroesSystem.sol
+++ b/packages/contracts/src/systems/RefreshHeroesSystem.sol
@@ -15,7 +15,7 @@ contract RefreshHeroesSystem is System {
     uint256 r = IWorld(_world()).getRandomNumberInGame(gameId);
 
     uint256 slotNumber = ShopConfig.getSlotNum(0);
-    uint256 creatureNumber = GameConfig.getCreatureIndex();
+    uint256 creatureCount = GameConfig.getCreatureIndex();
     char = new uint64[](slotNumber);
     // loop for each tier rate
     uint8[] memory tierRate = ShopConfig.getTierRate(0);
@@ -28,7 +28,8 @@ contract RefreshHeroesSystem is System {
         // it means the rate locates in j+1 tier
         if (remainder < tierRate[j]) {
           // creature Id + tier packed
-          char[i] = IWorld(_world()).encodeHero(uint32(r % creatureNumber), uint32(j));
+          // creature Id start from 1
+          char[i] = IWorld(_world()).encodeHero(uint32(r % creatureCount) + 1, uint32(j));
 
           break;
         }

--- a/packages/contracts/src/systems/ShopSystem.sol
+++ b/packages/contracts/src/systems/ShopSystem.sol
@@ -66,7 +66,7 @@ contract ShopSystem is System {
     Player.setCoin(player, Player.getCoin(player) + ShopConfig.getItemTierPrice(0, tier));
 
     // remove from inventory, set this as empty
-    Player.updateInventory(player, index, uint64(0));
+    Utils.popInventoryByIndex(player, index);
   }
 
   /**

--- a/packages/contracts/src/systems/ShopSystem.sol
+++ b/packages/contracts/src/systems/ShopSystem.sol
@@ -43,7 +43,7 @@ contract ShopSystem is System {
 
     (creatureId, tier) = IWorld(_world()).decodeHero(hero);
 
-    require(creatureId != 0, "empty hero slot");
+    require(creatureId != 0, "empty hero altar slot");
     // charge coin
     Player.setCoin(player, Player.getCoin(player) - ShopConfig.getItemTierPrice(0, tier));
 

--- a/packages/contracts/src/systems/ShopSystem.sol
+++ b/packages/contracts/src/systems/ShopSystem.sol
@@ -38,9 +38,6 @@ contract ShopSystem is System {
     // set the index as empty
     Player.updateHeroAltar(player, index, uint64(0));
 
-    // record on empty idx array
-    Player.pushHeroAltarEmptyIds(player, uint8(index));
-
     (creatureId, tier) = IWorld(_world()).decodeHero(hero);
 
     require(creatureId != 0, "empty hero altar slot");

--- a/packages/contracts/src/systems/ShopSystem.sol
+++ b/packages/contracts/src/systems/ShopSystem.sol
@@ -32,15 +32,23 @@ contract ShopSystem is System {
   function buyHero(uint256 index) public onlyInGame returns (uint32 creatureId, uint32 tier) {
     address player = _msgSender();
 
-    // pop hero info
-    uint64 hero = Utils.popHeroAltarByIndex(player, index);
+    // get hero info
+    uint64 hero = Player.getItemHeroAltar(player, index);
 
+    // set the index as empty
+    Player.updateHeroAltar(player, index, uint64(0));
+
+    // record on empty idx array
+    Player.pushHeroAltarEmptyIds(player, uint8(index));
+
+    (creatureId, tier) = IWorld(_world()).decodeHero(hero);
+
+    require(creatureId != 0, "empty hero slot");
     // charge coin
-    (, tier) = IWorld(_world()).decodeHero(hero);
-    Player.setCoin(player, Player.getCoin(player) - ShopConfig.getItemTierPrice(0,tier));
+    Player.setCoin(player, Player.getCoin(player) - ShopConfig.getItemTierPrice(0, tier));
 
     // recuit the hero
-    IWorld(_world()).decodeHero(_recruitAnHero(player, hero));
+    _recruitAnHero(player, hero);
   }
 
   /**
@@ -55,14 +63,10 @@ contract ShopSystem is System {
     uint32 tier = IWorld(_world()).decodeHeroToTier(hero);
 
     // refund coin
-    Player.setCoin(player, Player.getCoin(player) + ShopConfig.getItemTierPrice(0,tier));
+    Player.setCoin(player, Player.getCoin(player) + ShopConfig.getItemTierPrice(0, tier));
 
-    // remove from inventory
-    // 1. swap sold one with last one
-    Player.updateInventory(player, index, Player.getItemInventory(player, Player.lengthInventory(player)));
-
-    // 2. pop inventory
-    Player.popInventory(player);
+    // remove from inventory, set this as empty
+    Player.updateInventory(player, index, uint64(0));
   }
 
   /**
@@ -87,10 +91,17 @@ contract ShopSystem is System {
       return _recruitAnHero(_player, hero);
     }
 
-    // check inventory not full
-    require(Player.lengthInventory(_player) < GameConfig.getInventorySlotNum(), "Inventory full");
-    // add to inventory
-    Player.pushInventory(_player, hero);
+    uint256 emptyIdsLength = Player.lengthInventoryEmptyIds(_player);
+    require(emptyIdsLength > 0, "Inventory full");
+
+    // find empty index
+    uint256 index = Player.getItemInventoryEmptyIds(_player, emptyIdsLength - 1);
+
+    // pop last one
+    Player.popInventoryEmptyIds(_player);
+
+    // set index in inventory
+    Player.updateInventory(_player, index, _hero);
   }
 
   function _checkPlayerInGame() internal view {

--- a/packages/contracts/src/systems/SurrenderSystem.sol
+++ b/packages/contracts/src/systems/SurrenderSystem.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.0;
+
+import { System } from "@latticexyz/world/src/System.sol";
+import { IWorld } from "../codegen/world/IWorld.sol";
+import { PlayerGlobal, Player, GameRecord, Game, WaitingRoom, WaitingRoomPassword, GameConfig, Board } from "../codegen/Tables.sol";
+import { PlayerStatus, GameStatus, BoardStatus } from "../codegen/Types.sol";
+import { Utils } from "../library/Utils.sol";
+
+contract SurrenderSystem is System {
+  function surrender() public {
+    address player = _msgSender();
+    require(PlayerGlobal.getStatus(player) == PlayerStatus.INGAME, "not in game");
+    uint32 gameId = PlayerGlobal.getGameId(player);
+    require(Game.getStatus(gameId) == GameStatus.PREPARING, "only during preparing");
+
+    // remove player from Game table
+    (int256 index, address[] memory players) = Utils.getIndexOfLivingPlayers(gameId, player);
+    Utils.popGamePlayerByIndex(gameId, uint256(index));
+
+    // clear board
+    Utils.deleteAllPieces(player);
+
+    // clear player
+    Utils.clearPlayer(gameId, player);
+  }
+}

--- a/packages/contracts/test/ShopTest.t.sol
+++ b/packages/contracts/test/ShopTest.t.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.0;
+import { MudV2Test } from "@latticexyz/std-contracts/src/test/MudV2Test.t.sol";
+import { Creature, CreatureData, CreatureConfig, GameConfig, Player, ShopConfig } from "../src/codegen/Tables.sol";
+import { GameRecord, Game, GameData } from "../src/codegen/Tables.sol";
+import { Hero, HeroData } from "../src/codegen/Tables.sol";
+import { Piece, PieceData } from "../src/codegen/Tables.sol";
+import { IWorld } from "../src/codegen/world/IWorld.sol";
+import { GameStatus } from "../src/codegen/Types.sol";
+
+import { console2 } from "forge-std/console2.sol";
+
+contract AutoBattleSystemTest is MudV2Test {
+  IWorld public world;
+
+  address _user1 = vm.addr(13);
+  address _user2 = vm.addr(14);
+
+  function setUp() public override {
+    // super.setUp();
+    worldAddress = abi.decode(vm.parseJson(vm.readFile("deploys/31337/latest.json"), ".worldAddress"), (address));
+    world = IWorld(worldAddress);
+
+    bytes32 roomId = bytes32("12345");
+
+    vm.prank(_user1);
+    world.createRoom(roomId, 3, bytes32(0));
+
+    vm.prank(_user2);
+    world.joinRoom(roomId);
+
+    vm.startPrank(_user1);
+    world.startGame(roomId);
+    vm.stopPrank();
+  }
+
+  function testBuyHeroOne() public {
+    vm.prank(_user1);
+    world.buyHero(0);
+  }
+
+  function testBuyHeroTwoFail() public {
+    vm.startPrank(_user1);
+    world.buyHero(0);
+    vm.expectRevert("empty hero slot");
+    world.buyHero(0);
+    vm.stopPrank();
+  }
+
+  function testBuyDifferentTwoHero() public {
+    vm.startPrank(_user1);
+    world.buyHero(0);
+    world.buyHero(1);
+    vm.stopPrank();
+  }
+}

--- a/packages/contracts/test/ShopTest.t.sol
+++ b/packages/contracts/test/ShopTest.t.sol
@@ -73,4 +73,23 @@ contract ShopSystemTest is MudV2Test {
     assertEq(Player.getItemInventory(world, _player1, 0), heroOne);
     assertEq(Player.getItemInventory(world, _player1, 1), heroTwo);
   }
+
+  function testPlaceBackHeroToSpecificSlot(uint256 slotSeed) public {
+    vm.startPrank(_player1);
+    // buy hero
+    world.buyHero(0);
+    world.buyHero(1);
+
+    uint64 heroOne = Player.getItemInventory(world, _player1, 0);
+    uint64 heroTwo = Player.getItemInventory(world, _player2, 1);
+
+    // place hero to board
+    world.placeToBoard(0, 0, 1);
+
+    // place first hero to  3th slot
+    // world.placeBackInventory(0);
+    world.placeBackInventoryAndSwap(0, 2);
+
+    assertEq(Player.getItemInventory(world, _player1, 2), heroOne);
+  }
 }


### PR DESCRIPTION
@aLIEzsss4 

Break change:

1. `creatureId` start from 1, rather than 0. 0 means the slot is null. Former jugg is creatureId 0, and now jugg is creatureId 8.

Feat: 

1. new function `placeBackInventoryAndSwap` to move hero from board to a specfic inventory slot. `placeBackInventory` is not deleted, for backward compatible.
2. add `inventoryEmptyIds` to `Player` table. It gives default value if index of inventory is not provided. 
        

Config change:

1. the shop only refresh tier 1 hero only. Probability raffle function is not delete as it can be used for later hero rarity raffle.

Chore: 
1. move `surrender` as a independent system, in case of too large contract
3. merge work properly as `popInventoryByIndex` is modified.
