### PR TITLE
ci: add auto deploy action

### DIFF
--- a/.github/workflows/nightly-deploy.yaml
+++ b/.github/workflows/nightly-deploy.yaml
@@ -1,0 +1,80 @@
+name: nightly deploy contract
+
+on:
+  push:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 20 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  FOUNDRY_PROFILE: ci
+  PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          ref: "develop" # checkout develop
+
+      - uses: pnpm/action-setup@v2.2.4
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 8
+          run_install: false
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "pnpm"
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: build contracts
+        run: cd packages/contracts; pnpm build
+
+      - name: deploy on alt layer
+        run: cd packages/contracts; pnpm run deploy:alt
+
+      # refer https://github.com/orgs/community/discussions/26560#discussioncomment-3531273
+      - name: commit new address to develop branch
+        run: |
+          t=`date +%s`;
+          branch=deploy-${t}
+          git checkout -b $branch
+          git add packages/contracts/worlds.json;
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com";
+          git config user.name "github-actions[bot]"; 
+          git commit -m "chore(deployments)":" deploy on testnet";
+          git push origin $branch;
+          gh pr create --title "chore(deployments): auto deploy" --body "" --base develop --head $branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: build client
+        run: cd packages/client; pnpm build
+
+      - name: Vercel Action
+        uses: amondnet/vercel-action@v25
+
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN_DEV }} # Required
+          vercel-org-id: ${{ secrets.ORG_ID_DEV}} #Required
+          vercel-project-id: ${{ secrets.PROJECT_ID_DEV}} #Required
+          working-directory: ./packages/client/dist
+          vercel-args: "--prod" #Optional
+          scope: ${{secrets.TEAM_SLUG_DEV}}
+          alias-domains: "vercel-autochessia-dev.vercel.app"


### PR DESCRIPTION
This pr will set up a cron to deploy latest contract in develop branch at night. The build will be deployed to `dev.autochessia.xyz` and world address will be pushed to a new branch and create a pr, like #93.

There are other alternative ways to fulfill this. Need to research and back here.